### PR TITLE
Support pinning version when installing in windows

### DIFF
--- a/public/ps.html
+++ b/public/ps.html
@@ -1,8 +1,13 @@
-## Kindly inspired by Porter.sh Windows install script
+
+param (
+  [Parameter()]
+  $Version = "latest"
+)
+
 $COMTRYA_REPO = "comtrya/comtrya"
 $COMTRYA_FILE_WINDOWS = "comtrya-x86_64-pc-windows-msvc.exe"
 
-$COMTRYA_LATEST_RELEASE_URI = "https://api.github.com/repos/$COMTRYA_REPO/releases/latest"
+$COMTRYA_LATEST_RELEASE_URI = "https://api.github.com/repos/$COMTRYA_REPO/releases/$Version"
 $COMTRYA_URL = ((Invoke-RestMethod -Method GET -Uri $COMTRYA_LATEST_RELEASE_URI).assets | Where-Object name -EQ $COMTRYA_FILE_WINDOWS ).browser_download_url
 
 $COMTRYA_HOME="$env:USERPROFILE\.comtrya"


### PR DESCRIPTION
Here is a backwards compatiable method for specifying the version when installing Comtrya on windows:

using this test file: 

```powershell
param (
    [Parameter()]
    $Version = 'latest'
)

write-host "Version: $Version"
```

Then: 

```shell
$ npx serve
```

Then in another `pwsh` terminal:

```powershell
PS /home/zenobius/Projects/Mine/Github/Dotfiles> & ([scriptblock]::Create((iwr http://localhost:3000/version.ps1))) 1.2.3       
Version: 1.2.3   

PS /home/zenobius/Projects/Mine/Github/Dotfiles> iex "&{ $(iwr http://localhost:3000/version.ps1 -UseBasicParsing) } 1.2"
Version: 1.2                                                               

PS /home/zenobius/Projects/Mine/Github/Dotfiles> & ([scriptblock]::Create((iwr http://localhost:3000/version.ps1))) 
Version: latest 
                                                                                                        
PS /home/zenobius/Projects/Mine/Github/Dotfiles> iwr http://localhost:3000/version.ps1 -UseBasicParsing | iex 
Version: latest 
```

ideal one looks like : `iex "&{ $(iwr http://localhost:3000/version.ps1 -UseBasicParsing) } 1.2"`


investigated trying: 

```
iwr http://localhost:3000/version.ps1 -UseBasicParsing | iex -- -Version 1.2.3
```
result: iwr and iex don't work like this.

```
iwr http://localhost:3000/version.ps1 -UseBasicParsing | iex -Version 1.2.3
```
result: fails, because it thinks `-Version` is for `iex`

```
iwr http://localhost:3000/version.ps1 -UseBasicParsing | iex 1.2.3
```
result: fails, because it thinks `1.2.3` is for `iex`

