### PR TITLE
When testing for valid version, just rely on http status instead

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -110,7 +110,7 @@ getPackage() {
         rm "$targetFile"
     fi
 
-    url=https://github.com/$OWNER/$REPO/releases/download/$version/$REPO$suffix
+    url=https://github.com/$OWNER/$REPO/releases/download/$VERSION/$REPO$suffix
     echo "Downloading package $url as $targetFile"
 
     curl -sSL $url --output "$targetFile"

--- a/public/index.html
+++ b/public/index.html
@@ -9,21 +9,27 @@ export REPO=comtrya
 export SUCCESS_CMD="$REPO --help"
 export BINLOCATION="/usr/local/bin"
 
+inferVersionFromLatest() {
+    echo $(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep -i "location:" | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
+}
 
+validateVersion() {
+    local version=$1
+    local status=$(curl -s -o /dev/null https://github.com/$OWNER/$REPO/releases/$version -w "%{http_code}")
 
-hasVersion=$(curl -s -o /dev/null https://github.com/$OWNER/$REPO/releases/${VERSION:=latest} -w "%{http_code}")
-if [ $hasVersion -eq "200" ]; then
-    echo "Failed while attempting to install $REPO. Please manually install:"
-    echo ""
-    echo "1. Open your web browser and go to https://github.com/$OWNER/$REPO/releases"
-    echo "2. Download the latest release for your platform. Call it '$REPO'."
-    echo "3. chmod +x ./$REPO"
-    echo "4. mv ./$REPO $BINLOCATION"
-    if [ -n "$ALIAS_NAME" ]; then
-        echo "5. ln -sf $BINLOCATION/$REPO /usr/local/bin/$ALIAS_NAME"
+    if [ $status != "200" ]; then
+        echo "Failed while attempting to install $REPO. Please manually install:"
+        echo ""
+        echo "1. Open your web browser and go to https://github.com/$OWNER/$REPO/releases"
+        echo "2. Download the latest release for your platform. Call it '$REPO'."
+        echo "3. chmod +x ./$REPO"
+        echo "4. mv ./$REPO $BINLOCATION"
+        if [ -n "$ALIAS_NAME" ]; then
+            echo "5. ln -sf $BINLOCATION/$REPO /usr/local/bin/$ALIAS_NAME"
+        fi
+        exit 1
     fi
-    exit 1
-fi
+}
 
 hasCli() {
 
@@ -61,6 +67,8 @@ getPackage() {
     userid=$(id -u)
 
     suffix=""
+    
+    version=$1
 
     case $uname in
 
@@ -110,7 +118,7 @@ getPackage() {
         rm "$targetFile"
     fi
 
-    url=https://github.com/$OWNER/$REPO/releases/download/$VERSION/$REPO$suffix
+    url=https://github.com/$OWNER/$REPO/releases/download/$version/$REPO$suffix
     echo "Downloading package $url as $targetFile"
 
     curl -sSL $url --output "$targetFile"
@@ -176,4 +184,7 @@ getPackage() {
 }
 
 hasCli
-getPackage
+
+version=${VERSION:=$(inferVersionFromLatest)}
+validateVersion $version
+getPackage $version

--- a/public/index.html
+++ b/public/index.html
@@ -10,8 +10,9 @@ export SUCCESS_CMD="$REPO --help"
 export BINLOCATION="/usr/local/bin"
 
 
-version=$(curl -sI https://github.com/$OWNER/$REPO/releases/${VERSION:=latest} | grep -i "location:" | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
-if [ ! $version ]; then
+
+hasVersion=$(curl -s -o /dev/null https://github.com/$OWNER/$REPO/releases/${VERSION:=latest} -w "%{http_code}")
+if [ $hasVersion -eq "200" ]; then
     echo "Failed while attempting to install $REPO. Please manually install:"
     echo ""
     echo "1. Open your web browser and go to https://github.com/$OWNER/$REPO/releases"


### PR DESCRIPTION
fixes https://github.com/comtrya/comtrya/issues/309


If all we're doing here is testing if the version is available, then this will be more portable.

When ever I tried to run the existing technique, there was only a location field for the `latest` release: 


```
[zenobius@brass Dotfiles]$ echo $OWNER $REPO $VERSION
comtrya comtrya v0.8.3

```


```
[zenobius@brass Dotfiles]$ curl -sI https://github.com/$OWNER/$REPO/releases/latest
HTTP/2 302 
server: GitHub.com
date: Tue, 17 Jan 2023 08:39:10 GMT
content-type: text/html; charset=utf-8
vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
location: https://github.com/comtrya/comtrya/releases/tag/v0.8.3
cache-control: no-cache
strict-transport-security: max-age=31536000; includeSubdomains; preload
x-frame-options: deny
x-content-type-options: nosniff
x-xss-protection: 0
referrer-policy: no-referrer-when-downgrade
content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
set-cookie: _gh_sess=AaZF8g4ngN91U35mN%2BGzorcfz%2F1u%2BBWBqm3qWhGiOqs%2Fp8Leuj6yJ%2B1lDrStuwM2UFBHDPd1UYX4kHotrSiGOY9sJLyY9a6OK7fPZH7gG77Buh6sVjUF3YrywlJiIa0TmqaI6kK%2BZgsTvSk78JhM9NdHLwo6Sx1bBDDsmalIltI6gTxPxcDInJCuAjJXRJ%2Fcioa6rDHTQ%2F8rOJFFnsopc%2BtrlP3E57S%2FlREDwW7AtokC%2BEeU9oNm4L3iVsZfBD1AaXMQYN8zRXwTVW8yu%2BdSzg%3D%3D--1Zk29p9xbQNkeDxh--yI%2BVItDHDJnVPT5UYt37MA%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax
set-cookie: _octo=GH1.1.1591050746.1673944784; Path=/; Domain=github.com; Expires=Wed, 17 Jan 2024 08:39:44 GMT; Secure; SameSite=Lax
set-cookie: logged_in=no; Path=/; Domain=github.com; Expires=Wed, 17 Jan 2024 08:39:44 GMT; HttpOnly; Secure; SameSite=Lax
content-length: 0
x-github-request-id: 699E:2BD6:335988:3AC21A:63C65ED0

```

vs for `v0.8.1`: 

```
[zenobius@brass Dotfiles]$ curl -sI https://github.com/$OWNER/$REPO/releases/v0.8.1
HTTP/2 200 
server: GitHub.com
date: Tue, 17 Jan 2023 08:40:35 GMT
content-type: text/html; charset=utf-8
vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
etag: W/"3f277e26b465333445523f9ad5102473"
cache-control: max-age=0, private, must-revalidate
strict-transport-security: max-age=31536000; includeSubdomains; preload
x-frame-options: deny
x-content-type-options: nosniff
x-xss-protection: 0
referrer-policy: no-referrer-when-downgrade
content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
set-cookie: _gh_sess=NoDR0CZE1FmEEdAy3NsHpsZboIkMvrzpEvWXlqDwhzvCcwDbBaFaZYqrC3x5OrmP%2FRa3q08Icg0%2BXa35TTJfhp08RYjLrWTMnm6d5VBJRNIp0eYLA%2FBLuZS4Znr7FfLg9G7hUDd95tqY7DDASbPQGpHaXYgBZLEBDQVgRj3hmpsKrI0xDDpstL0KftOg8wWO9Neb4ddZT63ULCsdaNix%2BCYaBTg%2BX%2FYG5spUu%2F9Z0iIctvkVWZzof2O%2B%2BZhDqMHIoSy%2FOSOP0fk1YCnuT0kKfw%3D%3D--PcsT4OhagqaGQybE--k%2BbZL6U%2B%2BVrQKFZIgq8jcw%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax
set-cookie: _octo=GH1.1.847562738.1673944834; Path=/; Domain=github.com; Expires=Wed, 17 Jan 2024 08:40:34 GMT; Secure; SameSite=Lax
set-cookie: logged_in=no; Path=/; Domain=github.com; Expires=Wed, 17 Jan 2024 08:40:34 GMT; HttpOnly; Secure; SameSite=Lax
accept-ranges: bytes
x-github-request-id: 68A8:7CB7:A6813B:C525FD:63C65F02

```

this is because the `releases/latest` is not a real version and so it's a 302 redirect which is why there's a `location` field and no response

The other versions are urls that return a response body, so no `location` field.

If all we're trying to do is test if the version is real in your releases page, then we can test for the http status code.

```
[zenobius@brass Dotfiles]$ [ $(curl -s -o /dev/null https://github.com/$OWNER/$REPO/releases/v0.8.1 -w "%{http_code}") -eq "200" ] && echo "yes"
yes
[zenobius@brass Dotfiles]$ [ $(curl -s -o /dev/null https://github.com/$OWNER/$REPO/releases/v0.8.44 -w "%{http_code}") -eq "200" ] && echo "yes" || echo "no"
no
```


edit: 

- realised the initial curl request was trying to validate the version and infer the version at the same time. so it needs to be split.


```
[zenobius@brass Dotfiles]$ VERSION=v0.8.0 ./getcomtrya.sh 
x86_64
Downloading package https://github.com/comtrya/comtrya/releases/download/v0.8.0/comtrya-x86_64-unknown-linux-gnu as /home/zenobius/Projects/Mine/Github/Dotfiles/comtrya-x86_64-unknown-linux-gnu
Download complete.

============================================================
  The script was run as a user who is unable to write
  to /usr/local/bin. To complete the installation the
  following commands may need to be run manually.
============================================================

  sudo cp comtrya-x86_64-unknown-linux-gnu /usr/local/bin/comtrya
  sudo ln -sf /usr/local/bin/comtrya /usr/local/bin/comtrya

[zenobius@brass Dotfiles]$ VERSION=v0.8.3333 ./getcomtrya.sh 
Failed while attempting to install comtrya. Please manually install:

1. Open your web browser and go to https://github.com/comtrya/comtrya/releases
2. Download the latest release for your platform. Call it 'comtrya'.
3. chmod +x ./comtrya
4. mv ./comtrya /usr/local/bin
5. ln -sf /usr/local/bin/comtrya /usr/local/bin/comtrya
[zenobius@brass Dotfiles]$ 
```

